### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-dirgir"
+description = "A collection of ComfyUI directory automation utility nodes. Directory Get It Right adds a GUI directory browser, and smart directory loop/iteration node that supports regex and file extension filtering."
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["aiohttp", "tk"]
+
+[project.urls]
+Repository = "https://github.com/AshMartian/ComfyUI-DirGir"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-DirGir"
+Icon = ""


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://www.comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [x] Go to the [registry](https://www.comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [x] Write a short the description.
- [x] Merge the separate Github Actions PR and run the workflow.
If you want to publish the node manually, [install the cli](https://www.comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`


Please message me on [Discord](https://discord.com/invite/comfycontrib) if you have any questions!